### PR TITLE
Changed assert_mime_type to detect audio files with ID3

### DIFF
--- a/playtime
+++ b/playtime
@@ -112,7 +112,7 @@ eprint() {
 
 assert_mime_type() {
   local file=$1
-  if [[ "$(file -b --mime-type "$file")" =~ ^(audio)|(video) ]] ; then
+  if [[ "$(file -b "$file")" =~ ^([Aa]udio)|([Vv]ideo) ]] ; then
     return 0
   else
     return 1


### PR DESCRIPTION
Mp3s with ID3 file --mime-type is application/octet-stream and were skipped by assert_file_type(). This fixes that issue.